### PR TITLE
Update to fmt/101 signature

### DIFF
--- a/signatures/fmt/875.json
+++ b/signatures/fmt/875.json
@@ -65,7 +65,13 @@
       "signatureType": "File extension"
     }
   ],
-  "relationships": [],
+  "relationships": [
+    {
+      "relationshipType": "Has priority over",
+      "relatedFormatID": 638,
+      "relatedFormatName": "Extensible Markup Language"
+    }
+  ],
   "supportedBy": 200,
   "developedBy": 200,
   "source": 1


### PR DESCRIPTION
[fmt/875](http://www.nationalarchives.gov.uk/PRONOM/fmt/875): RDF/XML. Priority added over fmt/101 Extensible Markup Language 1.0. Submitted by Preservica.