### PR TITLE
Release v.124

### DIFF
--- a/signatures/fmt/101.json
+++ b/signatures/fmt/101.json
@@ -724,8 +724,14 @@
       "relationshipType": "Has lower priority than",
       "relatedFormatID": 3955,
       "relatedFormatName": "xdomea"
+    },
+    {
+      "relationshipType": "Has lower priority than",
+      "relatedFormatID": 1679,
+      "relatedFormatName": "RDF/XML"
     }
   ],
   "developedBy": 106,
-  "source": 1
+  "source": 1,
+  "containerSignatures": []
 }

--- a/signatures/fmt/875.json
+++ b/signatures/fmt/875.json
@@ -65,7 +65,13 @@
       "signatureType": "File extension"
     }
   ],
-  "relationships": [],
+  "relationships": [
+    {
+      "relationshipType": "Has priority over",
+      "relatedFormatID": 638,
+      "relatedFormatName": "Extensible Markup Language"
+    }
+  ],
   "supportedBy": 200,
   "developedBy": 200,
   "source": 1

--- a/signatures/fmt/875.json
+++ b/signatures/fmt/875.json
@@ -74,5 +74,6 @@
   ],
   "supportedBy": 200,
   "developedBy": 200,
-  "source": 1
+  "source": 1,
+  "containerSignatures": []
 }


### PR DESCRIPTION
[fmt/875](http://www.nationalarchives.gov.uk/PRONOM/fmt/875): RDF/XML. Priority added over fmt/101 Extensible Markup Language 1.0. Submitted by Preservica.